### PR TITLE
Update caching documentation to current state

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/ClearCache/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/ClearCache/Index.rst
@@ -9,13 +9,17 @@
 Clearing the cache after editing records
 ----------------------------------------
 
-If a news record is created or edited, chances are high that the changes are not visible in the frontend as the output is still cached.
-Therefore you need to clear the caches of the list and single view pages. This can be done automatically by using this command in the PageTsConfig: ::
+News has a built-in mechanism that takes care of clearing the cache after manipulation of News records.
+
+When a list or detail view is rendered on a page, a cache tag in format ``tx_news_pid_PID`` (where PID is the uid of the news storage folder) is added. Each time a news record is edited, deleted or created, this cache entry is flushed. No additional cache configuration is needed if only the News plugins are used.
+
+If you use other ways of displaying news records (e.g. an RSS feed created by TypoScript on a page without a News plugin), the cache is not flushed automatically.
+
+This can be done automatically by using this command in the PageTsConfig: ::
 
 	TCEMAIN.clearCacheCmd = 123,456,789
 
-
-The code needs to be added to the sys folder where the news records are edited. Change the example page ids to the ones which should be cleared, e.g. the one of list views and detail view.
+The code needs to be added to the sys folder where the news records are edited. Change the example page ids to the ones which should be cleared, e.g. a page with an RSS feed.
 You can use: ::
 
 	TCEMAIN.clearCacheCmd = pages
@@ -24,8 +28,8 @@ to clear the complete caches as well ::
 
 	TCEMAIN.clearCacheCmd = cacheTag:tx_news
 
-to clear all caches of pages on which the news plugins are used
+to clear all caches of pages on which the news plugins are used but beware of performance issues when news records are edited often.
 
-.. tip::
+.. Hint::
 
 	The mentioned TCEMAIN settings are part of the TYPO3 core and can be used therefore not only for the news extension.


### PR DESCRIPTION
As opposed to the documentation, News takes care of clearing the cache of pages with a News plugin itself. Configuration of cache clearing is only necessary in edge cases, e.g. when using News content through TypoScript objects. This must be reflected in the documentation.