### PR TITLE
Update RSS setup path

### DIFF
--- a/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
+++ b/Documentation/AdministratorManual/BestPractice/Rss/Index.rst
@@ -177,7 +177,7 @@ Don't forget to configure the RSS feed properly as the sample template won't ful
 
 .. code-block:: typoscript
 
-    plugin.tx_news {
+    plugin.tx_news.settings.list {
     	rss.channel {
     		title = Dummy Title
     		description =


### PR DESCRIPTION
The correct typoscript setup path for rss channel settings is `plugin.tx_news.settings.list.rss.channel`, not `plugin.tx_news.rss.channel`